### PR TITLE
metadata

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Manual/* linguist-documentation


### PR DESCRIPTION
Currently, this repo appears to search engines, etc. as a PostScript program. Adding this metadata file allows searchers to see this is a Matlab program. This [program](https://github.com/scivision/linguist-python) detects languages like GitHub does:

before:

```
PostScript 72.80%
MATLAB 17.22%
TeX 4.59%
Perl 1.52%
C 1.35%
C++ 1.29%
```

with this .gitattributes file:

```
MATLAB 76.17%
Perl 6.74%
C 5.98%
C++ 5.69%
Shell 4.44%
Makefile 0.42%
Python 0.25%
```