### PR TITLE
Fix undefined behaviour.

### DIFF
--- a/src/calamp.c
+++ b/src/calamp.c
@@ -37,7 +37,7 @@ using namespace std;
 // =======================================================================
 // Start of program 
 // =======================================================================
-int cshortswap( complex<short>* f )
+void cshortswap( complex<short>* f )
 {
   char* b = reinterpret_cast<char*>(f);
   complex<short> f2;
@@ -49,7 +49,7 @@ int cshortswap( complex<short>* f )
   f[0]=f2;
 }
 
-int cfloatswap( complex<float>* f )
+void cfloatswap( complex<float>* f )
 {
   char* b = reinterpret_cast<char*>(f);
   complex<float> f2;

--- a/src/selpsc_patch.c
+++ b/src/selpsc_patch.c
@@ -47,7 +47,7 @@ using namespace std;
 // =======================================================================
 // Start of program 
 // =======================================================================
-int cshortswap( complex<short>* f )
+void cshortswap( complex<short>* f )
 {
   char* b = reinterpret_cast<char*>(f);
   complex<short> f2;
@@ -59,7 +59,7 @@ int cshortswap( complex<short>* f )
   f[0]=f2;
 }
 
-int shortswap( short* f )
+void shortswap( short* f )
 {
   char* b = reinterpret_cast<char*>(f);
   short f2;
@@ -69,7 +69,7 @@ int shortswap( short* f )
   f[0]=f2;
 }
 
-int cfloatswap( complex<float>* f )
+void cfloatswap( complex<float>* f )
 {
   char* b = reinterpret_cast<char*>(f);
   complex<float> f2;
@@ -85,7 +85,7 @@ int cfloatswap( complex<float>* f )
   f[0]=f2;
 }
 
-int floatswap( float* f )
+void floatswap( float* f )
 {
   char* b = reinterpret_cast<char*>(f);
   float f2;
@@ -97,7 +97,7 @@ int floatswap( float* f )
   f[0]=f2;
 }
 
-int longswap( int32_t* f )
+void longswap( int32_t* f )
 {
   char* b = reinterpret_cast<char*>(f);
   int32_t f2;

--- a/src/selsbc_patch.c
+++ b/src/selsbc_patch.c
@@ -48,7 +48,7 @@ using namespace std;
 // =======================================================================
 // Start of program 
 // =======================================================================
-int cshortswap( complex<short>* f )
+void cshortswap( complex<short>* f )
 {
   char* b = reinterpret_cast<char*>(f);
   complex<short> f2;
@@ -60,7 +60,7 @@ int cshortswap( complex<short>* f )
   f[0]=f2;
 }
 
-int cfloatswap( complex<float>* f )
+void cfloatswap( complex<float>* f )
 {
   char* b = reinterpret_cast<char*>(f);
   complex<float> f2;
@@ -75,7 +75,7 @@ int cfloatswap( complex<float>* f )
   b2[7] = b[4];
   f[0]=f2;
 }
-int longswap( int32_t* f )
+void longswap( int32_t* f )
 {
   char* b = reinterpret_cast<char*>(f);
   int32_t f2;


### PR DESCRIPTION
In C++ functions returning non-void must finish with a "return"
statement. Otherwise this brings to undefined behaviour, which in
my particular case (GCC 9.3.0 on Debian unstable) causes a segmentation
fault.