### PR TITLE
Corrections for importing from a GAMMA stack

### DIFF
--- a/bin/mt_prep_gamma
+++ b/bin/mt_prep_gamma
@@ -140,7 +140,6 @@ else
 endif
 echo "Precision is" $prec
 
-end
 echo "gamma" > processor.txt
 if ($SB_FLAG == 1) then
     matlab -nojvm -nosplash -nodisplay < $STAMPS/matlab/sb_parms_initial.m > sb_parms_initial.log

--- a/matlab/ps_load_initial_gamma.m
+++ b/matlab/ps_load_initial_gamma.m
@@ -47,7 +47,7 @@ ifgs=textscan(fid,'%s');
 fclose(fid);
 ifgs=ifgs{1}(2:end);
 nb=length(ifgs{1});
-master_day=str2num(ifgs{1}(nb-21:nb-14));
+master_day=str2num(ifgs{1}(nb-27:nb-20));
 n_ifg=length(ifgs);
 n_image=n_ifg;
 day=zeros(n_ifg,1);

--- a/matlab/sb_load_initial_gamma.m
+++ b/matlab/sb_load_initial_gamma.m
@@ -138,7 +138,7 @@ end
 
 ll0=(max(lonlat)+min(lonlat))/2;
 
-xy=llh2local(lonlat,ll0)'*1000;
+xy=llh2local(lonlat',ll0)'*1000;
 
 sort_x=sortrows(xy,1);
 sort_y=sortrows(xy,2);


### PR DESCRIPTION
Several corrections have been done in the StaMPS scripts regarding the use of InSAR stack from GAMMA. 

## mt_prep_gamma

````bash 
136     else  
137         echo "Unknown image format in" $RSC 
138         exit(4)
139     endif
140 endif
141 echo "Precision is" $prec
142
143 end #<-- This "end"
144 echo "gamma" > processor.txt
145 if ($SB_FLAG == 1) then
146     matlab -nojvm -nosplash -nodisplay < $STAMPS/matlab/sb_parms_initial.m > sb_parms_initial.log
147 else
148     matlab -nojvm -nosplash -nodisplay < $STAMPS/matlab/ps_parms_initial.m > ps_parms_initial.log
149 endif
````
## ps_load_initial_gamma

Old: 
````matlab 
50 master_day=str2num(ifgs{1}(nb-21:nb-14));
````
New:
````matlab 
50 master_day=str2num(ifgs{1}(nb-27:nb-20));
````

## sb_load_initial_gamma

Old: 
````matlab 
141 xy=llh2local(lonlat,ll0)'*1000;
````
New:
````matlab 
141 xy=llh2local(lonlat',ll0)'*1000;
````